### PR TITLE
Changed to<unit> functions

### DIFF
--- a/driver/escaping/escape_sequences.cpp
+++ b/driver/escaping/escape_sequences.cpp
@@ -252,26 +252,6 @@ string processFunction(const StringView seq, Lexer & lex) {
         lex.Consume();
         return "replaceRegexpOne(" + param + ", '^\\\\s+', '')";
 
-    } else if (fn.type == Token::DAYOFWEEK) {
-        if (!lex.Match(Token::LPARENT))
-            return seq.to_string();
-
-        auto param = processIdentOrFunction(seq, lex /*, false*/);
-        if (param.empty())
-            return seq.to_string();
-        lex.Consume();
-        return "if(toDayOfWeek(" + param + ") = 7, 1, toDayOfWeek(" + param + ") + 1)";
-/*
-    } else if (fn.type == Token::DAYOFYEAR) {
-        if (!lex.Match(Token::LPARENT))
-            return seq.to_string();
-
-        auto param = processIdentOrFunction(seq, lex);
-        if (param.empty())
-            return seq.to_string();
-        lex.Consume();
-        return "( toRelativeDayNum(" + param + ") - toRelativeDayNum(toStartOfYear(" + param + ")) + 1 )";
-*/
     } else if (function_map.find(fn.type) != function_map.end()) {
         string result = function_map.at(fn.type);
         auto func = result;

--- a/driver/escaping/escape_sequences.cpp
+++ b/driver/escaping/escape_sequences.cpp
@@ -186,18 +186,25 @@ string processFunction(const StringView seq, Lexer & lex) {
         if (!lex.Match(Token::LPARENT))
             return seq.to_string();
 
-        if (function_map.find(fn.type) == function_map.end())
-            return seq.to_string();
+        if (function_map.find(fn.type) == function_map.end()) {
+			LOG("TIMESTAMPADD not found");
+			return seq.to_string();
+		}
         string func = function_map.at(fn.type);
         Token type = lex.Consume();
-        if (units_map.find(type.type) == units_map.end())
-            return seq.to_string();
+		if (units_map.find(type.type) == units_map.end()) {
+			LOG("Unit " << type.literal << " not found");
+			return seq.to_string();
+		}
         string addUnits = units_map.at(type.type);
+		LOG("Preparing " << func << " for unit type " << addUnits);
         if (!lex.Match(Token::COMMA))
             return seq.to_string();
         auto ramount = processIdentOrFunction(seq, lex);
-        if (ramount.empty())
-            return seq.to_string();
+		if (ramount.empty()) {
+			LOG("Could not parse ramount");
+			return seq.to_string();
+		}
 
         while (lex.Match(Token::SPACE)) {
         }
@@ -207,8 +214,10 @@ string processFunction(const StringView seq, Lexer & lex) {
 
 
         auto rdate = processIdentOrFunction(seq, lex);
-        if (rdate.empty())
-            return seq.to_string();
+		if (rdate.empty()) {
+			LOG("Cold not parse rdate for");
+			return seq.to_string();
+		}
 
         if (!func.empty()) {
             while (lex.Match(Token::SPACE)) {

--- a/driver/escaping/function_declare.h
+++ b/driver/escaping/function_declare.h
@@ -61,21 +61,21 @@
     // Date
     DECLARE2(CURDATE, "today"),
     DECLARE2(CURRENT_DATE, "today"),
-    DECLARE2(DAYOFMONTH, "toDayOfMonth"),
-    // DECLARE2(DAYOFWEEK, " toDayOfWeek"), // special handling
-    DECLARE2(DAYOFYEAR, " toDayOfYear"),
+    DECLARE2(DAYOFMONTH, "toDayOfMonth"), //not found in docs
+    DECLARE2(DAYOFWEEK, "DayOfWeek"),
+    DECLARE2(DAYOFYEAR, " toDayOfYear"), //not found in docs
     DECLARE2(EXTRACT, "EXTRACT"), // Do not touch extract inside {fn ... }
     DECLARE2(TIMESTAMPADD, "dateAdd"),
     //Consider deleting all of the below functions
-    DECLARE2(HOUR, "toHour"),
-    DECLARE2(MINUTE, "toMinute"),
-    DECLARE2(MONTH, "toMonth"),
+    DECLARE2(HOUR, "Hour"),
+    DECLARE2(MINUTE, "Minute"),
+    DECLARE2(MONTH, "Month"),
     DECLARE2(NOW, "now"),
-    DECLARE2(SECOND, "toSecond"),
+    DECLARE2(SECOND, "Second"),
     DECLARE2(TIMESTAMPDIFF, "dateDiff"),
-    DECLARE2(WEEK, "toISOWeek"),
-    DECLARE2(SQL_TSI_QUARTER, "toQuarter"),
-    DECLARE2(YEAR, "toYear"),
+    DECLARE2(WEEK, "toISOWeek"), //not found in docs
+    DECLARE2(SQL_TSI_QUARTER, "Quarter"),
+    DECLARE2(YEAR, "Year"),
 
     // DECLARE2(DATABASE, ""),
     DECLARE2(IFNULL, "ifNull"),

--- a/driver/escaping/function_declare.h
+++ b/driver/escaping/function_declare.h
@@ -61,9 +61,9 @@
     // Date
     DECLARE2(CURDATE, "today"),
     DECLARE2(CURRENT_DATE, "today"),
-    DECLARE2(DAYOFMONTH, "toDayOfMonth"), //not found in docs
+    DECLARE2(DAYOFMONTH, "DayOfMonth"),
     DECLARE2(DAYOFWEEK, "DayOfWeek"),
-    DECLARE2(DAYOFYEAR, " toDayOfYear"), //not found in docs
+    DECLARE2(DAYOFYEAR, " DayOfYear"), 
     DECLARE2(EXTRACT, "EXTRACT"), // Do not touch extract inside {fn ... }
     DECLARE2(TIMESTAMPADD, "dateAdd"),
     //Consider deleting all of the below functions
@@ -73,7 +73,7 @@
     DECLARE2(NOW, "now"),
     DECLARE2(SECOND, "Second"),
     DECLARE2(TIMESTAMPDIFF, "dateDiff"),
-    DECLARE2(WEEK, "toISOWeek"), //not found in docs
+    DECLARE2(WEEK, "WeekOfYear"),
     DECLARE2(SQL_TSI_QUARTER, "Quarter"),
     DECLARE2(YEAR, "Year"),
 

--- a/driver/escaping/lexer_declare.h
+++ b/driver/escaping/lexer_declare.h
@@ -1,7 +1,7 @@
 
 // clang-format off
 
-    DECLARE(DAYOFWEEK),
+    //DECLARE(DAYOFWEEK),
     //DECLARE(TIMESTAMPADD),
     DECLARE(CONVERT),
     DECLARE(LOCATE),


### PR DESCRIPTION
Previously driver used CLickHouse functions `toHour`, `toYear`, etc. Now it uses our options. See #3
Please, note that I could not find some functions in docks like `DayOfYear` and `DayOfMonth`
@alexandertokarev @rodionos are they presented in ATSD? If yes, how are they used, if no, will they be added?